### PR TITLE
Add username to GameFlowDto and enhance event updates with player details

### DIFF
--- a/Backend/Enums/GameEventType.cs
+++ b/Backend/Enums/GameEventType.cs
@@ -9,6 +9,7 @@ public enum GameEventType
     QuestionRobbingIsAllowed,
     QuestionRobbed,
     QuestionAnswered,
+    QuestionAnsweredWrong,
     PlayerJoined,
     PlayerLeft,
     PlayerDisconnected,

--- a/Backend/Models/DTOs/GameFlowDto.cs
+++ b/Backend/Models/DTOs/GameFlowDto.cs
@@ -8,6 +8,7 @@ namespace Backend.Models.DTOs;
 public class GameFlowDto
 {
     public long? UserId { get; set; }
+    public string? Username { get; set; }
     public required string SessionId { get; set; }
     public long? QuestionId { get; set; }
     public string? Answer { get; set; }

--- a/Backend/Services/GameFlowService.cs
+++ b/Backend/Services/GameFlowService.cs
@@ -166,7 +166,7 @@ public class GameFlowService(
         if (currentGame.CurrentGameUsers.Count > 1)
         {
             currentGame = await serviceUtil.SelectNextPlayer(currentGame);
-            var currentUser = currentGame.CurrentGameUsers.First(u => u.IsCurrent)?.User;
+            var currentUser = currentGame.CurrentGameUsers.FirstOrDefault(u => u.IsCurrent)?.User;
             gameFlowDto.Username = currentUser?.Username;
             await serviceUtil.UpdateGameFlow(gameFlowDto, GameEventType.NextPlayerSelected);
         }

--- a/Backend/Services/GameFlowService.cs
+++ b/Backend/Services/GameFlowService.cs
@@ -34,6 +34,7 @@ public class GameFlowService(
 
         await unitOfWork.CompleteAsync();
 
+        gameFlowDto.Username = userToAdd.Username;
         await serviceUtil.UpdateGameFlow(gameFlowDto, GameEventType.PlayerJoined);
     }
 
@@ -54,7 +55,9 @@ public class GameFlowService(
         var currentGame = await serviceUtil.GetAndValidateCurrentGame(GameEventType.QuestionSelected, gameFlowDto, GetUserId());
 
         await serviceUtil.SelectNextQuestion(currentGame, gameFlowDto.QuestionId!.Value);
-
+        var currentUser = currentGame.CurrentGameUsers.FirstOrDefault(cgu => cgu.IsCurrent)?.User;
+        
+        gameFlowDto.Username = currentUser?.Username;
         await serviceUtil.UpdateGameFlow(gameFlowDto, GameEventType.QuestionSelected);
     }
 
@@ -62,10 +65,13 @@ public class GameFlowService(
     {
         var currentGame = await serviceUtil.GetAndValidateCurrentGame(GameEventType.AnswerSubmitted, gameFlowDto, GetUserId());
         var currentQuestion = currentGame.CurrentGameQuestions.First(q => q.IsCurrent);
+        var currentUser = currentGame.CurrentGameUsers.FirstOrDefault(cgu => cgu.IsCurrent)?.User;
         await unitOfWork.CurrentGameQuestions.IncludeReferenceAsync(currentQuestion, cgq => cgq.Question);
 
         var question = await unitOfWork.Questions.GetByIdAsync(currentQuestion.QuestionId);
 
+        gameFlowDto.Username = currentUser?.Username;
+        
         if (question != default &&
             string.Equals(question.Answer.RemoveAccents(), gameFlowDto.Answer?.RemoveAccents(), StringComparison.CurrentCultureIgnoreCase))
         {
@@ -87,6 +93,7 @@ public class GameFlowService(
         else if (question != default)
         {
             await serviceUtil.SetQuestionRobbingAllowed(currentGame, currentQuestion);
+            await serviceUtil.UpdateGameFlow(gameFlowDto, GameEventType.QuestionAnsweredWrong);
             await serviceUtil.UpdateGameFlow(gameFlowDto, GameEventType.QuestionRobbingIsAllowed);
         }
     }
@@ -95,9 +102,12 @@ public class GameFlowService(
     {
         var currentGame = await serviceUtil.GetAndValidateCurrentGame(GameEventType.AnswerSubmitted, gameFlowDto, GetUserId());
         var currentQuestion = currentGame.CurrentGameQuestions.First(q => q.IsCurrent && q.IsRobbingAllowed);
-
+        var currentUser = currentGame.CurrentGameUsers.FirstOrDefault(cgu => cgu.UserId == GetUserId())?.User;
+        
         var question = await unitOfWork.Questions.GetByIdAsync(currentQuestion.QuestionId);
 
+        gameFlowDto.Username = currentUser?.Username;
+        
         if (question != default &&
             string.Equals(question.Answer.RemoveAccents(), gameFlowDto.Answer?.RemoveAccents(), StringComparison.CurrentCultureIgnoreCase))
         {
@@ -118,7 +128,7 @@ public class GameFlowService(
         }
         else if (question != default)
         {
-            await serviceUtil.UpdateGameFlow(gameFlowDto, GameEventType.QuestionRobbingIsAllowed);
+            await serviceUtil.UpdateGameFlow(gameFlowDto, GameEventType.QuestionAnsweredWrong);
         }
     }
 
@@ -126,21 +136,19 @@ public class GameFlowService(
     {
         var currentGame = await serviceUtil.GetAndValidateCurrentGame(GameEventType.PlayerLeft, gameFlowDto, GetUserId());
         var playerToRemove = currentGame.CurrentGameUsers.First(u => u.UserId == gameFlowDto.UserId);
-
-        // Check if the leaving player is the current turn player
+        
         var wasCurrentPlayer = playerToRemove.IsCurrent;
-
+        
         await unitOfWork.CurrentGameUsers.RemoveAsync(playerToRemove);
         await unitOfWork.CompleteAsync();
-
-        // If the leaving player was the current turn player, select the next player
+        
         if (wasCurrentPlayer && currentGame.CurrentGameUsers.Count > 1)
         {
-            // Refresh the current game to get updated user list without the removed player
             currentGame = await serviceUtil.GetAndValidateCurrentGame(GameEventType.PlayerLeft, gameFlowDto, GetUserId());
             await serviceUtil.SelectNextPlayer(currentGame);
         }
 
+        gameFlowDto.Username = playerToRemove.User.Username;
         await serviceUtil.UpdateGameFlow(gameFlowDto, GameEventType.PlayerLeft);
     }
 
@@ -157,7 +165,9 @@ public class GameFlowService(
         var currentGame = await serviceUtil.GetAndValidateCurrentGame(GameEventType.NextPlayerSelected, gameFlowDto, GetUserId());
         if (currentGame.CurrentGameUsers.Count > 1)
         {
-            await serviceUtil.SelectNextPlayer(currentGame);
+            currentGame = await serviceUtil.SelectNextPlayer(currentGame);
+            var currentUser = currentGame.CurrentGameUsers.First(u => u.IsCurrent)?.User;
+            gameFlowDto.Username = currentUser?.Username;
             await serviceUtil.UpdateGameFlow(gameFlowDto, GameEventType.NextPlayerSelected);
         }
     }


### PR DESCRIPTION
This pull request enhances game event tracking and user identification within the game flow logic. The most significant changes introduce a new event type for wrong answers, ensure the current user's username is included in the game flow data, and update the handling of game events to reflect these improvements.

**Game event tracking improvements:**

* Added a new event type, `QuestionAnsweredWrong`, to the `GameEventType` enum to explicitly represent when a player answers a question incorrectly.

**User identification enhancements:**

* Added a new `Username` property to the `GameFlowDto` data transfer object to carry the current user's username with each relevant game event.
* Updated various service methods (`AddUserToCurrentGame`, `SelectQuestion`, `SubmitAnswer`, `RobQuestion`, `LeaveGame`, and `SelectNextPlayer`) to set the `Username` field in `GameFlowDto` based on the current user or affected player. [[1]](diffhunk://#diff-e133c54fdb1a78598fb938351e5df2473d7f12e71f93fa5619ac70791ab6f324R37) [[2]](diffhunk://#diff-e133c54fdb1a78598fb938351e5df2473d7f12e71f93fa5619ac70791ab6f324R58-R74) [[3]](diffhunk://#diff-e133c54fdb1a78598fb938351e5df2473d7f12e71f93fa5619ac70791ab6f324R105-R110) [[4]](diffhunk://#diff-e133c54fdb1a78598fb938351e5df2473d7f12e71f93fa5619ac70791ab6f324L130-R151) [[5]](diffhunk://#diff-e133c54fdb1a78598fb938351e5df2473d7f12e71f93fa5619ac70791ab6f324L160-R170)

**Game flow logic updates:**

* Modified the handling of wrong answers in `SubmitAnswer` and `RobQuestion` to trigger the new `QuestionAnsweredWrong` event, improving clarity in game state transitions. [[1]](diffhunk://#diff-e133c54fdb1a78598fb938351e5df2473d7f12e71f93fa5619ac70791ab6f324R96) [[2]](diffhunk://#diff-e133c54fdb1a78598fb938351e5df2473d7f12e71f93fa5619ac70791ab6f324L121-R131)